### PR TITLE
Add accessible hidden H1 to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ hide:
   - toc
 ---
 
+# Urbano {.sr-only}
+
 <style>
 .md-content__button {
     display: none;
@@ -20,18 +22,6 @@ hide:
 .center-text {
   text-align: center;
   display: block;
-}
-/* find better solution for this later */
-.md-typeset h1 {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
 }
 
 .mdx-users {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -37,3 +37,17 @@ span.version {
 span.faint {
   color: #8792a2;
 }
+
+/* Screen reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
Replaces the inline CSS hack for hiding the generated H1 on the homepage with a robust, accessible solution. Adds a '.sr-only' utility class to 'docs/stylesheets/extra.css' and explicitly adds an '# Urbano {.sr-only}' heading to 'docs/index.md'. This ensures screen readers can identify the page's main heading ("Urbano") while maintaining the visual design (logo + subtitle).

---
*PR created automatically by Jules for task [6039764934387440741](https://jules.google.com/task/6039764934387440741) started by @kastnerp*