### PR TITLE
🎨 Palette: Enhance Documentation Landing Page CTAs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-26 - Replacing Raw HTML Buttons with Markdown
+**Learning:** `mkdocs-material` allows using markdown syntax inside HTML containers if the `markdown` attribute is present on the container. This enables using theme features like icons and button styles more cleanly than raw HTML.
+**Action:** Use `markdown` attribute on wrapper `div`s when needing complex layout but wanting to use markdown components.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,10 +67,12 @@ hide:
 
 ![Urbano Example Canvas](assets/images/combo.jpg){.skip-lightbox}
 
-<div align="center">
-  <a href="https://docs.urbano.io/" class="md-button md-button--primary">Get Started</a>
-  <a href="https://www.food4rhino.com/en/app/urbano" class="md-button" target="_blank" rel="noopener noreferrer" aria-label="Download V1 (opens in a new tab)">Download V1</a>
-  <a href="https://rhinopackages.github.io/?search=urbano&sort=2&p=Urbano2" class="md-button" target="_blank" rel="noopener noreferrer" aria-label="Download V2 (opens in a new tab)">Download V2</a>
+<div align="center" markdown>
+
+[:material-rocket-launch: Get Started](https://docs.urbano.io/){ .md-button .md-button--primary }
+[:material-download: Download V1](https://www.food4rhino.com/en/app/urbano){ .md-button target="_blank" rel="noopener noreferrer" aria-label="Download V1 (opens in a new tab)" }
+[:material-download: Download V2](https://rhinopackages.github.io/?search=urbano&sort=2&p=Urbano2){ .md-button target="_blank" rel="noopener noreferrer" aria-label="Download V2 (opens in a new tab)" }
+
 </div>
 
 


### PR DESCRIPTION
💡 **What:** Replaced raw HTML buttons on the documentation landing page with Markdown syntax buttons that include Material Design icons.
🎯 **Why:** To improve the visual appeal and scanability of the primary Call-to-Actions (Get Started, Download V1, Download V2).
📸 **Before/After:** Verified with Playwright screenshot showing correct rendering of icons and button styles.
♿ **Accessibility:** Maintained `aria-label` attributes and link behaviors (`target="_blank"`, `rel="noopener noreferrer"`). Added icons to reinforce meaning.

---
*PR created automatically by Jules for task [15112256723143282131](https://jules.google.com/task/15112256723143282131) started by @kastnerp*