### PR TITLE
🎨 Palette: Add accessibility attributes to external LinkedIn link in announcement bar

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -19,10 +19,10 @@
 <!-- Announcement bar -->
 {% block announce %}
   For updates follow <strong>Urbano</strong> on
-  <a rel="me" href="https://www.linkedin.com/company/urbano-io">
-    <span class="twemoji linkedin">
+  <a rel="me noopener noreferrer" target="_blank" href="https://www.linkedin.com/company/urbano-io">
+    <span class="twemoji linkedin" aria-hidden="true">
       {% include ".icons/fontawesome/brands/linkedin.svg" %}
     </span>
-    <strong>LinkedIn</strong>
+    <strong>LinkedIn</strong><span class="sr-only"> (opens in a new tab)</span>
   </a>
 {% endblock %}


### PR DESCRIPTION
💡 What: Added accessibility attributes (`target="_blank"`, `rel="me noopener noreferrer"`) and an `aria-hidden` attribute to the external LinkedIn link icon in the global announcement bar (`docs/overrides/main.html`). Added a visually hidden span containing text about opening in a new tab.

🎯 Why: The original link opened in the same tab without any indication to the user (or screen readers) that they were navigating away. Improving this adheres to common UX patterns and secures the link with `noopener noreferrer`.

📸 Before/After: The visual UI remains perfectly unchanged since the icon is hidden only to assistive technologies and the added text is visually hidden (`.sr-only`).

♿ Accessibility: Ensures that screen reader users are notified the link opens in a new tab by reading "LinkedIn (opens in a new tab)" rather than getting redundant output. The decorative LinkedIn icon is now ignored (`aria-hidden="true"`).

---
*PR created automatically by Jules for task [343417991248163451](https://jules.google.com/task/343417991248163451) started by @kastnerp*