### PR TITLE
🎨 Palette: Improve text color contrast in docs

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,24 +18,24 @@ a.field {
 
 span.parent-field {
   font-weight: 600;
-  color:#a3acb9;
+  color: #70767f;
   font-size: .85em;
 }
 
 span.type {
-  color: #8792a2;
+  color: #6e7784;
   font-size: .7rem;
   margin-right: 4px;
 }
 
 span.version {
-  color: #8792a2;
+  color: #6e7784;
   font-size: .7rem;
   float: right;
 }
 
 span.faint {
-  color: #8792a2;
+  color: #6e7784;
 }
 
 /* Screen reader only utility */


### PR DESCRIPTION
🎨 Palette: Improve text color contrast in docs

💡 What: Updated the font colors of `.parent-field`, `.type`, `.version`, and `.faint` classes in `docs/stylesheets/extra.css` from lighter grays (`#a3acb9`, `#8792a2`) to darker slate shades (`#70767f`, `#6e7784`).
🎯 Why: The previous light gray text against a white background had insufficient color contrast, making it harder to read. The new colors meet WCAG AA contrast ratio requirements (~4.5:1).
📸 Before/After: Visual changes apply to metadata sections rendering those classes.
♿ Accessibility: Improved color contrast for better readability.

---
*PR created automatically by Jules for task [5855921472118313113](https://jules.google.com/task/5855921472118313113) started by @kastnerp*