### PR TITLE
🎨 Palette: Add focus and hover states to primary buttons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,21 @@ hide:
   font-size: 16px;
   font-weight: bold;
   padding: 12px 24px;
+  transition: all 0.2s ease-in-out;
+}
+.md-button:hover,
+.md-button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 .md-button--primary {
   background-color: #007acc;
   color: white;
+}
+.md-button--primary:hover,
+.md-button--primary:focus-visible {
+  background-color: #005f9e;
+  outline-color: #005f9e;
 }
 .center-text {
   text-align: center;


### PR DESCRIPTION
💡 **What:** Added missing `:hover` and `:focus-visible` styles to the `.md-button` and `.md-button--primary` elements on the homepage.
🎯 **Why:** Users relying on keyboard navigation and mouse interactions lacked visual feedback when focusing or hovering over the main call-to-action buttons.
📸 **Before/After:** Verified via Playwright screenshots.
♿ **Accessibility:** Improves WCAG compliance for focus indicators and provides necessary interactive feedback.

---
*PR created automatically by Jules for task [10137455944224200122](https://jules.google.com/task/10137455944224200122) started by @kastnerp*