### PR TITLE
🎨 Palette: Respect user OS preferences for reduced motion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-26 - Replacing Raw HTML Buttons with Markdown
 **Learning:** `mkdocs-material` allows using markdown syntax inside HTML containers if the `markdown` attribute is present on the container. This enables using theme features like icons and button styles more cleanly than raw HTML.
 **Action:** Use `markdown` attribute on wrapper `div`s when needing complex layout but wanting to use markdown components.
+
+## 2025-03-09 - Added prefers-reduced-motion
+**Learning:** MkDocs material theme and custom CSS animations (like hover scaling on team photos and color transitions) did not respect the user's OS-level motion preferences, which can cause discomfort for users with vestibular disorders.
+**Action:** When adding custom CSS transitions (like `:hover` transforms or filter changes) in documentation sites, always wrap them or provide an override in a `@media (prefers-reduced-motion: reduce)` block to set `transition: none !important;` and `transform: none !important;`.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -51,3 +51,13 @@ span.faint {
   white-space: nowrap;
   border-width: 0;
 }
+
+/* Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .md-button,
+  .mdx-users__testimonial img,
+  .black-and-white {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
💡 **What:** Added a `@media (prefers-reduced-motion: reduce)` CSS block to disable hover transforms and filter transitions for users who have requested reduced motion in their OS settings.
🎯 **Why:** To improve accessibility by preventing discomfort or nausea for users with vestibular disorders when hovering over team photos and buttons.
📸 **Before/After:** (See attached Playwright verification screenshots showing no hover scale on `prefers-reduced-motion`).
♿ **Accessibility:** Added compliance with WCAG 2.1 Success Criterion 2.3.3 Animation from Interactions.

---
*PR created automatically by Jules for task [13470373625009299188](https://jules.google.com/task/13470373625009299188) started by @kastnerp*