### PR TITLE
🎨 Palette: Add accessible context to focusable team cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-03-09 - Silencing Duplicative Image Announcements in MkDocs
 **Learning:** In MkDocs Material feature cards, when an image represents the exact same concept as the adjacent bold heading (e.g., an icon for "Simulation" next to the text "Simulation"), screen readers will announce it twice. Markdown's `attr_list` extension allows overriding the default filename-based alt text by injecting `{ alt="" }` directly after the image definition (e.g., `![alt](url){ alt="" }`).
 **Action:** When creating visually rich feature cards with icons and headings in MkDocs, set the image alt text to empty (`alt=""`) via `attr_list` to reduce screen reader noise and improve navigation flow.
+
+## 2025-03-09 - Accessible Visual Focus on Non-Interactive Semantic Elements
+**Learning:** When using `tabindex="0"` on non-interactive semantic elements (like `<figure>`) to enable visual CSS hover/focus effects (like grayscale-to-color transitions) for keyboard users, screen readers will announce them as contextless, potentially confusing focus stops.
+**Action:** If a static element must be focusable for visual accessibility reasons, always provide semantic context by explicitly adding appropriate ARIA labeling, such as `role="group"` and an `aria-label` describing the content.

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,17 +110,17 @@ hide:
 
 <div class="mdx-users">
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0">
+<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Yang Yang">
     <img src="assets/images/team/yang.jpg" alt="" loading="lazy" class="skip-lightbox">
     <figcaption class="md-typeset">Yang Yang</figcaption>
   </figure>
   
-  <figure class="mdx-users__testimonial black-and-white" tabindex="0">
+  <figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Patrick Kastner">
     <img src="assets/images/team/kastner.jpg" alt="" loading="lazy" class="skip-lightbox">
     <figcaption class="md-typeset">Patrick Kastner</figcaption>
   </figure>
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0">
+<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Timur Dogan">
     <img src="assets/images/team/dogan.jpg" alt="" loading="lazy" class="skip-lightbox">
     <figcaption class="md-typeset">Timur Dogan</figcaption>
   </figure>
@@ -131,12 +131,12 @@ hide:
 
 <div class="mdx-users">
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0">
+<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Alumni and Advisor: Nikhil Saraf">
     <img src="assets/images/team/saraf.jpg" alt="" loading="lazy" class="skip-lightbox">
     <figcaption class="md-typeset">Nikhil Saraf</figcaption>
   </figure>
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0">
+<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Alumni and Advisor: Samitha Samaranayake">
     <img src="assets/images/team/samitha.jpg" alt="" loading="lazy" class="skip-lightbox">
     <figcaption class="md-typeset">Samitha Samaranayake
 </figcaption>


### PR DESCRIPTION
💡 **What:** Added `role="group"` and semantic `aria-label` attributes to the team and alumni `<figure>` cards on the homepage.
🎯 **Why:** The cards correctly use `tabindex="0"` to allow keyboard-only users to experience the CSS `:focus-visible` grayscale-to-color transition. However, making a generic non-interactive element like `<figure>` focusable without an accessible name acts as an accessibility anti-pattern for screen readers, as they announce contextless tab stops.
♿ **Accessibility:** Screen readers will now announce "group, Team member: [Name]" rather than announcing an ambiguous focus stop.
📚 **Journal:** Added a critical learning to `.Jules/palette.md` detailing this pattern for semantic elements that require visual focus.

---
*PR created automatically by Jules for task [12238502686779822867](https://jules.google.com/task/12238502686779822867) started by @kastnerp*