### PR TITLE
🎨 Palette: Hide decorative heading emojis from screen readers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ hide:
 
 ---
 
-## 👥 Team
+## <span aria-hidden="true">👥</span> Team
 
 
 <div class="mdx-users">
@@ -127,7 +127,7 @@ hide:
 
 </div>
 
-## 👥 Alumni & Advisors
+## <span aria-hidden="true">👥</span> Alumni & Advisors
 
 <div class="mdx-users">
 
@@ -158,7 +158,7 @@ Urbano is being developed as a cross-disciplinary project through a collaboratio
 
 ---
 
-## 🎉 Supporters
+## <span aria-hidden="true">🎉</span> Supporters
 
 <div class="grid" markdown>
 


### PR DESCRIPTION
💡 **What:** Wrapped decorative emojis in Markdown headings on `docs/index.md` with `<span aria-hidden="true">` tags.

🎯 **Why:** To prevent screen readers from automatically reading out the names of literal emojis (e.g., "Busts in silhouette Team"), which adds unnecessary navigation noise and degrades the accessibility of the headings.

♿ **Accessibility:** This is a standard a11y polish to keep screen reader output clean and focused on actual heading text while retaining the visual aesthetic of the emojis for sighted users.

No visual regressions. Tested via local MkDocs build and Playwright headless visual verification.

---
*PR created automatically by Jules for task [3914868649657780504](https://jules.google.com/task/3914868649657780504) started by @kastnerp*