### PR TITLE
🎨 Palette: Silence redundant screen reader announcement for hero logo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ hide:
 </style>
 
 <figure markdown="span">
-  ![Urbano Logo](assets/cd/android-chrome-512x512.png){ width="250" .skip-lightbox }
+  ![Urbano Logo](assets/cd/android-chrome-512x512.png){ width="250" .skip-lightbox alt="" }
 </figure>
 
 <p style="text-align: center; font-size: 24px;">


### PR DESCRIPTION
💡 What: Added an empty alt attribute (`alt=""`) to the Urbano logo image in `docs/index.md` using the Markdown `attr_list` extension.
🎯 Why: The image immediately follows an `.sr-only` visually hidden heading (`# Urbano`). By default, MkDocs or screen readers would read both the heading and the alt text/filename of the image ("Urbano Logo"), creating a redundant and confusing experience. Silencing the purely decorative image streamlines the flow for assistive technologies.
📸 Before/After: Visual layout remains unchanged (verified).
♿ Accessibility: Reduces screen reader noise by avoiding double-announcing the brand name.

---
*PR created automatically by Jules for task [10985872115656862433](https://jules.google.com/task/10985872115656862433) started by @kastnerp*