### PR TITLE
🎨 Palette: Add tactile hover and focus states to buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-09 - Accessible Visual Focus on Non-Interactive Semantic Elements
 **Learning:** When using `tabindex="0"` on non-interactive semantic elements (like `<figure>`) to enable visual CSS hover/focus effects (like grayscale-to-color transitions) for keyboard users, screen readers will announce them as contextless, potentially confusing focus stops.
 **Action:** If a static element must be focusable for visual accessibility reasons, always provide semantic context by explicitly adding appropriate ARIA labeling, such as `role="group"` and an `aria-label` describing the content.
+
+## 2025-03-09 - Maintaining Tactile Metaphor with Interactive Transforms
+**Learning:** A continuous tactile button interaction (lifting on `:hover`/`:focus-visible`, and pressing down on `:active`) requires coordinating the transforms between states. If `:active` overrides `transform` with just `scale()`, the `translateY` from the hover state is abruptly lost, causing a disjointed visual snap.
+**Action:** Always combine transforms on `:active` (e.g., `transform: translateY(0) scale(0.98)`) to smoothly resolve previous transforms and complete the physical interaction metaphor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,14 @@ hide:
   padding: 12px 24px;
   transition: all 0.2s ease-in-out;
 }
+.md-button:hover,
+.md-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
 .md-button:active {
-  transform: scale(0.98);
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .md-button--primary {
   background-color: #007acc;
@@ -34,6 +40,8 @@ hide:
 
 @media (prefers-reduced-motion: reduce) {
   .md-button,
+  .md-button:hover,
+  .md-button:focus-visible,
   .md-button:active,
   .mdx-users__testimonial img {
     transition: none !important;


### PR DESCRIPTION
💡 **What**: Added a tactile "lift and press" interaction to the primary `.md-button` components on the homepage.
🎯 **Why**: To provide better visual feedback and a more pleasant, responsive interaction. When users hover or focus on the main call-to-action buttons, they now lift up slightly and cast a shadow. When clicked, they press down smoothly.
📸 **Before/After**: The button visually responds to hover/focus and active states via CSS transforms.
♿ **Accessibility**: Ensured keyboard accessibility by explicitly styling `:focus-visible` identically to `:hover`. Updated the `@media (prefers-reduced-motion: reduce)` block to explicitly cover all the newly added pseudo-classes, guaranteeing motion is safely disabled for users with vestibular disorders.

---
*PR created automatically by Jules for task [5246731658087023904](https://jules.google.com/task/5246731658087023904) started by @kastnerp*