### PR TITLE
🎨 Palette: Add high-contrast focus outline to primary action buttons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,10 @@ hide:
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
+.md-button:focus-visible {
+  outline: 2px solid #007acc;
+  outline-offset: 4px;
+}
 .md-button:active {
   transform: translateY(0) scale(0.98);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
💡 **What**: Added a distinct `outline` and `outline-offset` to the `:focus-visible` pseudo-class for `.md-button` elements on the homepage.
🎯 **Why**: Previously, primary action buttons only changed their `transform` and `box-shadow` on focus. This wasn't distinct enough for keyboard-only or low-vision users. The new high-contrast outline (`#007acc`) matches the existing accessible focus states used for the team member avatars.
📸 **Before/After**: See attached `button-focus.png` in the verification payload.
♿ **Accessibility**: Improves WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by providing a highly visible keyboard focus indicator without affecting mouse users.

---
*PR created automatically by Jules for task [6752898648521089931](https://jules.google.com/task/6752898648521089931) started by @kastnerp*