### PR TITLE
🎨 Palette: Make supporter logos accessible, clickable cards

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -179,15 +179,15 @@ Urbano is being developed as a cross-disciplinary project through a collaboratio
 
 ## <span aria-hidden="true">🎉</span> Supporters
 
+
+
+
 <div class="grid" markdown>
 
-![AAP](assets/images/AAP_logo_stacked.png){width="150" .skip-lightbox loading=lazy .center} 
-{ .card }
+[![AAP](assets/images/AAP_logo_stacked.png){width="150" .skip-lightbox loading=lazy .center alt=""}](https://aap.cornell.edu/){ .card target="_blank" rel="noopener noreferrer" aria-label="Cornell AAP (opens in a new tab)" }
 
-![Cornell](assets/images/cornell.svg){width="125" .skip-lightbox loading=lazy .center} 
-{ .card }
+[![Cornell](assets/images/cornell.svg){width="125" .skip-lightbox loading=lazy .center alt=""}](https://www.cornell.edu/){ .card target="_blank" rel="noopener noreferrer" aria-label="Cornell University (opens in a new tab)" }
 
-![Atkinson](assets/images/atkinson.png){width="325" .skip-lightbox loading=lazy .center}
-{ .card }
+[![Atkinson](assets/images/atkinson.png){width="325" .skip-lightbox loading=lazy .center alt=""}](https://atkinson.cornell.edu/){ .card target="_blank" rel="noopener noreferrer" aria-label="Cornell Atkinson Center for Sustainability (opens in a new tab)" }
 
 </div>


### PR DESCRIPTION
**💡 What:** The "Supporters" section previously used `.card` styling on inert images, which gave them the visual affordance of being clickable. This change wraps the images in functional anchor tags pointing to their respective organizations (Cornell AAP, Cornell University, and Cornell Atkinson Center).

**🎯 Why:** Users expect logos styled as interactive cards to navigate to the associated entity. This micro-UX improvement fulfills that expectation, making the interface more intuitive and connected.

**♿ Accessibility:**
- Added `aria-label`s communicating where the link leads and that it opens in a new tab.
- Added `target="_blank"` and `rel="noopener noreferrer"` for secure external navigation.
- explicitly set the inner image `alt` text to `""` to prevent screen readers from redundantly announcing the image text, as the context is gracefully handled by the surrounding link's `aria-label`.

---
*PR created automatically by Jules for task [15862000345364012833](https://jules.google.com/task/15862000345364012833) started by @kastnerp*