### PR TITLE
🎨 Palette: Enhanced accessibility for external links and images

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,11 +111,11 @@ hide:
 
 <br>
 
-![Urbano Example Canvas](assets/images/combo.jpg){.skip-lightbox}
+![An example Rhino and Grasshopper canvas showing a neighborhood layout with an overlaid walkability analysis and colorful simulation components](assets/images/combo.jpg){.skip-lightbox}
 
 <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; gap: 1rem;" markdown>
 
-[:material-rocket-launch: Get Started](https://docs.urbano.io/){ .md-button .md-button--primary }
+[:material-rocket-launch: Get Started](https://docs.urbano.io/){ .md-button .md-button--primary target="_blank" rel="noopener noreferrer" aria-label="Get Started (opens in a new tab)" }
 [:material-download: Download V1](https://www.food4rhino.com/en/app/urbano){ .md-button target="_blank" rel="noopener noreferrer" aria-label="Download V1 (opens in a new tab)" }
 [:material-download: Download V2](https://rhinopackages.github.io/?search=urbano&sort=2&p=Urbano2){ .md-button target="_blank" rel="noopener noreferrer" aria-label="Download V2 (opens in a new tab)" }
 


### PR DESCRIPTION
💡 What: 
- Updated the alt text for the main "Urbano Example Canvas" image in the landing page (`docs/index.md`).
- Added `target="_blank"`, `rel="noopener noreferrer"`, and `aria-label` to the "Get Started" call-to-action link.

🎯 Why: 
- The previous image alt text ("Urbano Example Canvas") wasn't very descriptive for screen-reader users, whereas the new text provides specific details about the visual content.
- The "Get Started" link lacked explicit attributes to notify users it would open in a new tab, creating an inconsistent experience compared to the adjacent "Download" links.

♿ Accessibility: 
- Provides significantly better context for visually impaired users interacting with the hero image.
- Ensures screen readers announce the correct interaction expectations for the "Get Started" link.

---
*PR created automatically by Jules for task [10950824524711888864](https://jules.google.com/task/10950824524711888864) started by @kastnerp*