### PR TITLE
🎨 Palette: Improve accessibility color contrast in banner and footer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-03-24 - MkDocs Built-In Color Contrast & Links
+**Learning:** MkDocs Material built-in utility features (like the `.md-banner` announcement bar and `.md-copyright` footer text) can sometimes trigger accessibility violations such as `color-contrast` and `link-in-text-block`, particularly when combining dark modes/themes with default link colors (like the default blue), or lowering opacity on footer text too much.
+**Action:** When working with MkDocs Material, verify the color contrast of custom announcement links and footer text. explicitly override these classes in `extra.css` with `!important` tags if necessary to guarantee WCAG 2.0 AA compliance, and ensure links inside text blocks (like the "Material for MkDocs" footer link) have an explicit `text-decoration: underline`.
+
 ## 2026-02-26 - Replacing Raw HTML Buttons with Markdown
 **Learning:** `mkdocs-material` allows using markdown syntax inside HTML containers if the `markdown` attribute is present on the container. This enables using theme features like icons and button styles more cleanly than raw HTML.
 **Action:** Use `markdown` attribute on wrapper `div`s when needing complex layout but wanting to use markdown components.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -61,3 +61,18 @@ span.faint {
     transform: none !important;
   }
 }
+
+/* Fix accessibility contrast in banner and footer */
+.md-banner a[rel="me noopener noreferrer"],
+.md-banner a[rel="me noopener noreferrer"] > strong {
+  color: #ffffff !important;
+}
+
+.md-copyright {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.md-copyright a {
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}

--- a/test_attr_list.md
+++ b/test_attr_list.md
@@ -1,1 +1,0 @@
-[Researchgate <span class="sr-only"> (opens in a new tab)</span>](https://www.researchgate.net/profile/Yang-Yang-168/research){: target="_blank" rel="noopener noreferrer"}


### PR DESCRIPTION
💡 What: Improved color contrast and link discoverability in MkDocs Material default elements (announcement banner and copyright footer).
🎯 Why: The default colors for links in the announcement banner and footer text/links failed WCAG 2.0 AA minimum contrast (at least 4.5:1 ratio) on dark backgrounds, making them hard to read and interact with. Links inside text blocks also lacked distinct styling.
📸 Before/After: Verified visual changes with local browser testing.
♿ Accessibility: 
- Increased contrast ratio for the LinkedIn announcement link.
- Increased base text color opacity on the copyright footer.
- Added explicit `text-decoration: underline` for the MkDocs link in the footer to fix the "link-in-text-block" Axe violation.
- Documented findings in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [6767890672495988809](https://jules.google.com/task/6767890672495988809) started by @kastnerp*