### PR TITLE
🎨 Palette: Add tactile hover and active states to card links

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -38,7 +38,18 @@ span.faint {
   color: #6e7784;
 }
 
-/* Improve visibility of focused card links */
+/* Improve visibility and tactility of card links */
+.card {
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: block;
+}
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-2px);
+}
+.card:active {
+  transform: translateY(0) scale(0.98);
+}
 .card:focus-visible {
   outline: 2px solid #007acc;
   outline-offset: 4px;
@@ -63,7 +74,11 @@ span.faint {
 @media (prefers-reduced-motion: reduce) {
   .md-button,
   .mdx-users__testimonial img,
-  .black-and-white {
+  .black-and-white,
+  .card,
+  .card:hover,
+  .card:focus-visible,
+  .card:active {
     transition: none !important;
     transform: none !important;
   }


### PR DESCRIPTION
💡 What: Added CSS hover and active states using `transform` for the `.card` links in the Supporters section, bringing them in line with the button styling on the page. Also ensured these animations are disabled under `prefers-reduced-motion` settings.

🎯 Why: The `.card` links (Cornell AAP, Cornell, Atkinson logos) lacked interactive feedback when a user hovered or clicked on them, even though they already had focus-visible styles. This creates a disconnect in tactile interaction compared to the main CTA buttons.

♿ Accessibility: Added the `.card` hover and active states to the existing `prefers-reduced-motion` media query block to ensure smooth fallback for users who are sensitive to motion. No regression on `.card:focus-visible` styling.

---
*PR created automatically by Jules for task [9581115555610174540](https://jules.google.com/task/9581115555610174540) started by @kastnerp*