### PR TITLE
🎨 Palette: Remove empty alt text from main logo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ hide:
 </style>
 
 <figure markdown="span">
-  ![Urbano Logo](assets/cd/android-chrome-512x512.png){ width="250" .skip-lightbox alt="" }
+  ![Urbano Logo](assets/cd/android-chrome-512x512.png){ width="250" .skip-lightbox }
 </figure>
 
 <p style="text-align: center; font-size: 24px;">


### PR DESCRIPTION
💡 What: Removed the `alt=""` override from the `![Urbano Logo]` image definition on the homepage.
🎯 Why: Because the `h1` on the homepage is visually hidden and this logo effectively serves as the main heading, setting an empty `alt=""` completely hides it from screen readers, causing them to lack critical context when landing on the page.
📸 Before/After: Visual presentation is identical; this is an accessibility change only.
♿ Accessibility: Screen reader users will now correctly hear "Urbano Logo" instead of skipping the main structural branding image of the page.

---
*PR created automatically by Jules for task [14048272876877613320](https://jules.google.com/task/14048272876877613320) started by @kastnerp*