### PR TITLE
🎨 Palette: Enable lightbox zoom for detailed canvas image

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ hide:
 
 <br>
 
-![An example Rhino and Grasshopper canvas showing a neighborhood layout with an overlaid walkability analysis and colorful simulation components](assets/images/combo.jpg){.skip-lightbox}
+![An example Rhino and Grasshopper canvas showing a neighborhood layout with an overlaid walkability analysis and colorful simulation components](assets/images/combo.jpg)
 
 <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; gap: 1rem;" markdown>
 


### PR DESCRIPTION
💡 **What:** Enabled the `glightbox` plugin on the detailed application screenshot in `docs/index.md` by removing the `.skip-lightbox` class.
🎯 **Why:** The `combo.jpg` image displays a complex Rhino & Grasshopper software canvas with many tiny details and nodes. Previously, users could not enlarge it, making it difficult to read and understand the tool's capabilities. This provides an immediate usability improvement by letting them click to zoom in and examine the UI.
📸 **Before/After:** Before, clicking the image did nothing. Now, it opens in a responsive lightbox overlay.
♿ **Accessibility:** This doesn't modify alt text but provides a visual enlargement utility heavily aiding users with vision impairments or those viewing on smaller screens.

---
*PR created automatically by Jules for task [16904717590101108615](https://jules.google.com/task/16904717590101108615) started by @kastnerp*