### PR TITLE
Add dark mode toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,25 +60,24 @@ theme:
     - announce.dismiss
 
   palette:
-    primary: white
-    # - media: "(prefers-color-scheme)"
-    #   toggle:
-    #     icon: material/link
-    #     name: Switch to light mode
-    # - media: "(prefers-color-scheme: light)"
-    #   scheme: default
-    #   primary: black
-    #   accent: indigo
-    #   toggle:
-    #     icon: material/toggle-switch
-    #     name: Switch to dark mode
-    # - media: "(prefers-color-scheme: dark)"
-    #   scheme: slate
-    #   primary: black
-    #   accent: indigo
-    #   toggle:
-    #     icon: material/toggle-switch-off
-    #     name: Switch to system preference
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/theme-light-dark
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      accent: black
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch-off
+        name: Switch to system preference
 
 markdown_extensions:
   - md_in_html
@@ -158,5 +157,4 @@ plugins:
         #- name: documentation
         #  import_url: https://github.com/Eddy3D-Dev/Eddy3D-Documentation/?branch=main
         #  imports: [/docs/*]
-
 


### PR DESCRIPTION
## What changed
- added the same Material dark-mode palette toggle pattern used in the VIP-SMUR site
- enabled system, light, and dark theme modes in the MkDocs config

## Why
The Urbano website should support a dark theme using the same implementation pattern as the reference site.

## Validation
- built the site locally with `./.venv/bin/mkdocs build --site-dir /tmp/urbano-website-build`
- verified the generated HTML contains the dark-scheme palette configuration
