### PR TITLE
🎨 Palette: Add proper download attribute and accessibility label to video fallback link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ hide:
   <video autoplay loop muted playsinline controls preload="metadata" aria-label="Urbano workflow teaser video">
     <source src="assets/videos/Urbano2-WorkflowTeaser1.mp4" type="video/mp4">
     Your browser does not support embedded videos. You can
-    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4">download the teaser video here</a>.
+    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4" download target="_blank" rel="noopener noreferrer" aria-label="Download the Urbano teaser video (opens in a new tab)">download the teaser video here</a>.
   </video>
 </div>
 


### PR DESCRIPTION
💡 **What**: Added `download`, `target="_blank"`, `rel="noopener noreferrer"`, and an explicit `aria-label` to the fallback `<video>` download link in `docs/index.md`.

🎯 **Why**: The previous download link simply linked to an `.mp4` file, which typically causes the browser to replace the current tab with a video player instead of initiating a download. Adding the `download` attribute ensures the browser attempts to download the file directly, and adding `target="_blank"` with `rel="noopener noreferrer"` ensures it safely opens the link in a new tab if downloading isn't directly supported. Adding an `aria-label` gives screen reader users explicit context about what the link does, and that it opens in a new tab.

📸 **Before/After**: N/A - Visuals are unchanged (link remains the same color and styling).

♿ **Accessibility**: Adds a descriptive `aria-label` explaining that the link downloads a video and opens a new tab.

*(Note: Cleaned up earlier `mkdocs_serve.log` and verification artifact leftovers.)*

---
*PR created automatically by Jules for task [7315561125739244257](https://jules.google.com/task/7315561125739244257) started by @kastnerp*