### PR TITLE
🎨 Palette: Improve screen reader flow for inline link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-10-25 - Tactile Hover Effects for Transparent Logo Cards
 **Learning:** Applying standard `box-shadow` on cards (e.g., `<a class="card"><img></a>`) that contain transparent PNG/SVG logos produces an awkward rectangular shadow that ignores the image's contours. The user doesn't see a nice lifted logo, but a rigid bounding box.
 **Action:** Use `filter: drop-shadow(...)` instead of `box-shadow` for interactive image link cards. This correctly follows the alpha channel of the inner transparent images, providing a far more organic and pleasant tactile lift effect on `:hover` and `:active`.
+
+## 2024-11-20 - Inline Links and Screen Reader Phrasing
+**Learning:** For inline links embedded directly within a continuous sentence (e.g., "You can [download the video here]."), adding a full `aria-label` to the anchor tag (like `aria-label="Download the video (opens in a new tab)"`) breaks the grammatical structure for screen reader users. The screen reader reads the surrounding sentence text ("You can...") and then stops and abruptly reads the entirely separate, redundant label on the anchor tag ("Download the video..."), rather than naturally reading the phrase inline.
+**Action:** When adding accessibility context to a link that flows within a continuous sentence block, use a visually hidden span (like `<span class="sr-only"> (opens in a new tab)</span>`) appended inside the anchor tag rather than overriding the whole text with `aria-label`. This preserves the natural sentence flow for screen readers while still providing the necessary context.

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ hide:
   <video autoplay loop muted playsinline controls preload="metadata" aria-label="Urbano workflow teaser video">
     <source src="assets/videos/Urbano2-WorkflowTeaser1.mp4" type="video/mp4">
     Your browser does not support embedded videos. You can
-    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4" download target="_blank" rel="noopener noreferrer" aria-label="Download the Urbano teaser video (opens in a new tab)">download the teaser video here</a>.
+    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4" download target="_blank" rel="noopener noreferrer">download the teaser video here<span class="sr-only"> (opens in a new tab)</span></a>.
   </video>
 </div>
 


### PR DESCRIPTION
💡 **What:** Replaced the `aria-label` attribute on the inline download link in `docs/index.md` with a visually hidden `<span class="sr-only">`.

🎯 **Why:** When screen readers encounter an inline link embedded in a continuous sentence (e.g., "You can [download the video here]."), adding an overriding `aria-label` breaks the grammatical flow. The screen reader stops reading the sentence and abruptly reads the disjointed label. By appending visually hidden text instead, we preserve the natural sentence phrasing while still communicating that the link opens in a new tab.

♿ **Accessibility:** Replaced overriding `aria-label` with a `<span class="sr-only"> (opens in a new tab)</span>` for better grammatical flow on screen readers.

📓 **Journal:** Added learning entry regarding screen reader phrasing for inline links to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [2326360054720665337](https://jules.google.com/task/2326360054720665337) started by @kastnerp*