### PR TITLE
🎨 Palette: Enhance developer logos with interactive links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -165,9 +165,9 @@ hide:
 
 <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; gap: 2rem; margin: 3rem 0;" markdown>
 
-![Cornell Systems Engineering](assets/images/logo-systemseng.svg){width="350" .skip-lightbox loading=lazy}
+[![Cornell Systems Engineering](assets/images/logo-systemseng.svg){width="350" .skip-lightbox loading=lazy alt=""}](https://www.duffield.cornell.edu/sys/meng/){ .card target="_blank" rel="noopener noreferrer" aria-label="Cornell Systems Engineering (opens in a new tab)" }
 <span aria-hidden="true">:octicons-plus-24:</span>
-![Environmental Systems Lab](assets/images/eslab.svg){width="320" .skip-lightbox loading=lazy}
+[![Environmental Systems Lab](assets/images/eslab.svg){width="320" .skip-lightbox loading=lazy alt=""}](https://aap.cornell.edu/faculty-labs-research-groups/){ .card target="_blank" rel="noopener noreferrer" aria-label="Environmental Systems Lab (opens in a new tab)" }
 
 </div>
 


### PR DESCRIPTION
💡 What: Wrapped the previously static "Cornell Systems Engineering" and "Environmental Systems Lab" logos at the bottom of the homepage in interactive links pointing to their respective websites, and applied the `.card` hover effects to them.
🎯 Why: Users expect prominent developer and partner logos to be clickable links that direct them to more information. This aligns the layout with standard UX expectations and matches the visual treatment of the "Supporters" section just below it.
♿ Accessibility:
- Added explicit `aria-label`s to the new links to clearly communicate their destination.
- Marked the internal `<img>` tags with `alt=""` to avoid redundant screen reader announcements (since the link label provides the context).
- Included `target="_blank"` with `rel="noopener noreferrer"` for secure external linking.

---
*PR created automatically by Jules for task [13970408043683882653](https://jules.google.com/task/13970408043683882653) started by @kastnerp*