### PR TITLE
🎨 Palette: Fix a11y of hidden H1 on landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,16 @@ hide:
 
 <style>
 .md-content h1 {
-    display: none !important;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border-width: 0 !important;
 }
 .md-content__button {
     display: none;


### PR DESCRIPTION
💡 **What:** Replaced the `display: none !important;` CSS rule targeting the `h1` element in `docs/index.md` with an accessible `.sr-only` pattern utilizing `clip-path`.
🎯 **Why:** Using `display: none` completely removes the element from the accessibility tree. As a result, screen reader users were navigating a page that structurally lacked a main top-level heading (`h1`), which violates WCAG guidelines for predictable document structure. This change keeps the heading visually hidden as intended by the design, but allows assistive technologies to read and index it.
♿ **Accessibility:** Re-introduced the main document heading to the accessibility tree without altering the visual layout.

---
*PR created automatically by Jules for task [13682995740388157324](https://jules.google.com/task/13682995740388157324) started by @kastnerp*