### PR TITLE
🎨 Palette: Update misleading screen reader text on video download link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ hide:
   <video autoplay loop muted playsinline controls preload="metadata" aria-label="Urbano workflow teaser video">
     <source src="assets/videos/Urbano2-WorkflowTeaser1.mp4" type="video/mp4">
     Your browser does not support embedded videos. You can
-    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4" download target="_blank" rel="noopener noreferrer">download the teaser video here<span class="sr-only"> (opens in a new tab)</span></a>.
+    <a href="assets/videos/Urbano2-WorkflowTeaser1.mp4" download target="_blank" rel="noopener noreferrer">download the teaser video here<span class="sr-only"> (MP4 video download)</span></a>.
   </video>
 </div>
 


### PR DESCRIPTION
💡 **What:**
Updated the `.sr-only` visually hidden text on the `docs/index.md` video fallback link from "(opens in a new tab)" to "(MP4 video download)".

🎯 **Why:**
The link uses the HTML `download` attribute to prompt a file download of the teaser video. The previous screen-reader-only text inaccurately informed users that the link would simply open in a new tab. This fix sets accurate expectations for screen reader users about what clicking the link will do.

♿ **Accessibility:**
- Improved screen reader fallback phrasing to match the actual element behavior.

_Note: This is Palette's daily micro-UX improvement._

---
*PR created automatically by Jules for task [5934748248420226715](https://jules.google.com/task/5934748248420226715) started by @kastnerp*