### PR TITLE
🎨 Palette: Add interactive states to announcement banner link

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -101,7 +101,8 @@ span.faint {
   .card,
   .card:hover,
   .card:focus-visible,
-  .card:active {
+  .card:active,
+  .md-banner a[rel="me noopener noreferrer"] {
     transition: none !important;
     transform: none !important;
   }
@@ -120,4 +121,21 @@ span.faint {
 .md-copyright a {
   text-decoration: underline !important;
   text-underline-offset: 2px !important;
+}
+
+.md-banner a[rel="me noopener noreferrer"] {
+  transition: opacity 0.2s ease-in-out, outline 0.2s ease-in-out;
+  border-radius: 4px;
+}
+
+.md-banner a[rel="me noopener noreferrer"]:hover,
+.md-banner a[rel="me noopener noreferrer"]:focus-visible {
+  opacity: 0.8;
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}
+
+.md-banner a[rel="me noopener noreferrer"]:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 4px;
 }


### PR DESCRIPTION
💡 **What:** Added missing interactive visual states (hover underline/opacity shift, keyboard focus outline) to the external links inside the top announcement banner.
🎯 **Why:** Previously, the banner links lacked clear visual feedback when hovered over by a mouse or focused via keyboard navigation, making them feel less interactive and slightly inaccessible.
♿ **Accessibility:** 
- Added a high-contrast focus outline (`2px solid #ffffff` with a `4px` offset) to strictly support keyboard users.
- Added `.md-banner a` to the existing `prefers-reduced-motion` media query to ensure the newly added opacity and outline transitions are disabled for users preferring reduced motion.

---
*PR created automatically by Jules for task [11944368556340735241](https://jules.google.com/task/11944368556340735241) started by @kastnerp*