### PR TITLE
🎨 Palette: Improve button contrast and accessibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,13 +41,24 @@ hide:
   transform: translateY(0) scale(0.98);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+.md-button:not(.md-button--primary) {
+  border-color: #007acc;
+  color: #007acc;
+}
+.md-button:not(.md-button--primary):hover,
+.md-button:not(.md-button--primary):focus-visible {
+  background-color: #007acc;
+  color: white;
+}
 .md-button--primary {
   background-color: #007acc;
+  border-color: #007acc;
   color: white;
 }
 .md-button--primary:hover,
 .md-button--primary:focus-visible {
   background-color: #005f9e;
+  border-color: #005f9e;
 }
 .center-text {
   text-align: center;


### PR DESCRIPTION
💡 What: Added missing hover and `focus-visible` styles to the secondary "Download" button to use the primary accessible brand blue (`#007acc`) with white text. Added explicit border matching for primary buttons.
🎯 Why: The default hover background color for the secondary button (`rgb(82, 108, 254)`) failed WCAG AA color contrast guidelines against white text (scoring 4.26:1). Additionally, it lacked distinct `focus-visible` styling for keyboard users.
📸 Before/After: The hover state now cleanly matches the primary brand color (`#007acc`), ensuring legibility and consistency. Verified visually via Playwright.
♿ Accessibility: Ensures call-to-action buttons meet the WCAG AA minimum 4.5:1 contrast ratio on hover and significantly improves keyboard focus visibility.

---
*PR created automatically by Jules for task [11530252473718981245](https://jules.google.com/task/11530252473718981245) started by @kastnerp*