### PR TITLE
🎨 Palette: Add explicit focus ring to embedded video for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-XX-XX - MkDocs Inline Link Styling Collisions
 **Learning:** Adding global hover/focus styles (like `text-decoration: underline`) to `.md-typeset a` in a Material for MkDocs project unintentionally breaks the styling of explicitly designed interactive components like `.md-button`s, `.card`s, and `.headerlink`s.
 **Action:** When applying standard UX/A11y hover and focus affordances to inline text links in MkDocs, strictly scope the CSS selector using exclusions (e.g., `.md-typeset a:not(.md-button):not(.card):not(.headerlink)`) to ensure the changes only affect standard prose links without causing UI regressions on buttons or cards.
+
+## 2024-05-18 - Video Focus States in Hidden Overflow Containers
+**Learning:** When embedded elements like `<video>` or `<iframe>` are placed inside styled container divs with `border-radius` and `overflow: hidden` (a common pattern for UI cards and teasers), standard outer focus rings (`outline-offset: 2px` or similar) can be completely clipped and hidden by the container's overflow property.
+**Action:** Use a negative `outline-offset` (e.g., `outline-offset: -2px`) on elements that fill their overflow-hidden containers to ensure the focus ring draws inwards and remains fully visible to keyboard users.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -79,6 +79,11 @@ span.faint {
   background: #111;
 }
 
+.workflow-teaser video:focus-visible {
+  outline: 2px solid #007acc;
+  outline-offset: -2px;
+}
+
 /* Screen reader only utility */
 .sr-only {
   position: absolute;


### PR DESCRIPTION
### 💡 What: 
Added a visible focus ring to the `<video>` element inside the `.workflow-teaser` container.

### 🎯 Why:
The container holding the video element has `overflow: hidden`. When keyboard users focus the video element (tab index 10), the standard browser focus outline draws *outside* the video bounds, causing it to be completely clipped and hidden by the container. This made it impossible for keyboard users to visually identify when the video controls were focused. Using `outline-offset: -2px` draws the focus ring slightly inside the video boundaries, ensuring it remains visible.

### ♿ Accessibility:
- Restores keyboard navigation visibility to the homepage teaser video.
- Adheres to WCAG Focus Visible standards.

### 📸 Testing:
- Verified visually using an automated Playwright script simulating keyboard navigation.
- Confirmed focus ring visibility using standard `#007acc` theme color.

---
*PR created automatically by Jules for task [6505102924101405945](https://jules.google.com/task/6505102924101405945) started by @kastnerp*