### PR TITLE
🎨 Palette: Make workflow-teaser video focus visible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-XX-XX - MkDocs Inline Link Styling Collisions
 **Learning:** Adding global hover/focus styles (like `text-decoration: underline`) to `.md-typeset a` in a Material for MkDocs project unintentionally breaks the styling of explicitly designed interactive components like `.md-button`s, `.card`s, and `.headerlink`s.
 **Action:** When applying standard UX/A11y hover and focus affordances to inline text links in MkDocs, strictly scope the CSS selector using exclusions (e.g., `.md-typeset a:not(.md-button):not(.card):not(.headerlink)`) to ensure the changes only affect standard prose links without causing UI regressions on buttons or cards.
+
+## 2024-XX-XX - Focus Rings in `overflow: hidden` Containers
+**Learning:** When standard focus rings (`outline`) are applied to embedded media elements (like `<video>`) that fill parent containers with `overflow: hidden` (like a `.workflow-teaser`), the focus indicator gets completely clipped out of view, rendering the element seemingly inaccessible to keyboard users despite actually having focus.
+**Action:** When applying focus rings (like `:focus-visible`) to elements filling an `overflow: hidden` parent, use a negative `outline-offset` (e.g., `-2px`) to pull the focus indicator inward, ensuring it remains fully visible to keyboard users.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -152,3 +152,8 @@ span.faint {
   outline-offset: 4px;
   border-radius: 2px;
 }
+
+.workflow-teaser video:focus-visible {
+  outline: 2px solid #007acc;
+  outline-offset: -2px;
+}


### PR DESCRIPTION
💡 **What**: Added a negative `outline-offset` to the `:focus-visible` state of the `<video>` element within the `.workflow-teaser` block. Also documented a critical accessibility learning in the Palette journal regarding `overflow: hidden` and focus clipping.

🎯 **Why**: When keyboard users navigate to the `.workflow-teaser` video, the standard focus ring (`outline`) gets clipped by the parent container's `overflow: hidden` property, providing zero visual feedback. Pulling the outline inward ensures keyboard users can clearly see when the element has focus.

♿ **Accessibility**: Directly improves WCAG compliance for focus visibility (2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [16949346790397285540](https://jules.google.com/task/16949346790397285540) started by @kastnerp*