### PR TITLE
🎨 Palette: Fix dead tab stops by making team figures interactive

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-XX-XX - Focus Rings in `overflow: hidden` Containers
 **Learning:** When standard focus rings (`outline`) are applied to embedded media elements (like `<video>`) that fill parent containers with `overflow: hidden` (like a `.workflow-teaser`), the focus indicator gets completely clipped out of view, rendering the element seemingly inaccessible to keyboard users despite actually having focus.
 **Action:** When applying focus rings (like `:focus-visible`) to elements filling an `overflow: hidden` parent, use a negative `outline-offset` (e.g., `-2px`) to pull the focus indicator inward, ensuring it remains fully visible to keyboard users.
+## 2024-XX-XX - Dead Tab Stops on Non-Interactive Figures
+**Learning:** Applying `tabindex="0"` to non-interactive `<figure>` elements solely to trigger CSS pseudo-class effects (like `:focus-visible`) creates "dead" tab stops. Screen reader and keyboard users expect focusable elements to be actionable. This is a severe WCAG accessibility violation.
+**Action:** Never use `tabindex="0"` just for visual effects. Instead, either wrap the content in a semantic interactive element (like an `<a>` tag with a verified URL) or remove the focusability entirely if the element is purely static.

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,8 +97,9 @@ hide:
   transition: transform 0.3s ease-in-out, border-color 0.3s ease-in-out;
 }
 
-.mdx-users__testimonial:hover img,
-.mdx-users__testimonial:focus-visible img {
+.mdx-users__testimonial a:hover img,
+.mdx-users__testimonial a:focus-visible img,
+.mdx-users__testimonial div:hover img {
     transform: scale(1.05);
     border-color: #007acc;
 }
@@ -147,19 +148,25 @@ hide:
 
 <div class="mdx-users">
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Yang Yang">
-    <img src="assets/images/team/yang.jpg" alt="" loading="lazy" class="skip-lightbox">
-    <figcaption class="md-typeset">Yang Yang</figcaption>
+<figure class="mdx-users__testimonial">
+    <a href="https://yangyang.page/about.html" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Yang Yang (opens in a new tab)">
+        <img src="assets/images/team/yang.jpg" alt="" loading="lazy" class="skip-lightbox">
+        <figcaption class="md-typeset">Yang Yang</figcaption>
+    </a>
   </figure>
   
-  <figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Patrick Kastner">
-    <img src="assets/images/team/kastner.jpg" alt="" loading="lazy" class="skip-lightbox">
-    <figcaption class="md-typeset">Patrick Kastner</figcaption>
+  <figure class="mdx-users__testimonial">
+    <a href="https://arch.gatech.edu/people/patrick-kastner" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Patrick Kastner (opens in a new tab)">
+        <img src="assets/images/team/kastner.jpg" alt="" loading="lazy" class="skip-lightbox">
+        <figcaption class="md-typeset">Patrick Kastner</figcaption>
+    </a>
   </figure>
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Team member: Timur Dogan">
-    <img src="assets/images/team/dogan.jpg" alt="" loading="lazy" class="skip-lightbox">
-    <figcaption class="md-typeset">Timur Dogan</figcaption>
+  <figure class="mdx-users__testimonial">
+    <a href="https://aap.cornell.edu/people/timur-dogan/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Timur Dogan (opens in a new tab)">
+        <img src="assets/images/team/dogan.jpg" alt="" loading="lazy" class="skip-lightbox">
+        <figcaption class="md-typeset">Timur Dogan</figcaption>
+    </a>
   </figure>
 
 </div>
@@ -168,15 +175,18 @@ hide:
 
 <div class="mdx-users">
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Alumni and Advisor: Nikhil Saraf">
-    <img src="assets/images/team/saraf.jpg" alt="" loading="lazy" class="skip-lightbox">
-    <figcaption class="md-typeset">Nikhil Saraf</figcaption>
+<figure class="mdx-users__testimonial">
+    <div class="black-and-white" style="display: block;">
+        <img src="assets/images/team/saraf.jpg" alt="" loading="lazy" class="skip-lightbox">
+        <figcaption class="md-typeset">Nikhil Saraf</figcaption>
+    </div>
   </figure>
 
-<figure class="mdx-users__testimonial black-and-white" tabindex="0" role="group" aria-label="Alumni and Advisor: Samitha Samaranayake">
-    <img src="assets/images/team/samitha.jpg" alt="" loading="lazy" class="skip-lightbox">
-    <figcaption class="md-typeset">Samitha Samaranayake
-</figcaption>
+  <figure class="mdx-users__testimonial">
+    <a href="https://cee.cornell.edu/samitha/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Samitha Samaranayake (opens in a new tab)">
+        <img src="assets/images/team/samitha.jpg" alt="" loading="lazy" class="skip-lightbox">
+        <figcaption class="md-typeset">Samitha Samaranayake</figcaption>
+    </a>
   </figure>
 
 </div>


### PR DESCRIPTION
💡 **What:** The UX enhancement wraps the non-interactive profile images in the Team and Alumni sections with interactive anchor tags pointing to their respective professional pages (and strips the `tabindex` from any unlinked images).
🎯 **Why:** The previous code applied `tabindex="0"` to static `<figure>` elements just to trigger a `.black-and-white:focus-visible` CSS filter. This created "dead" tab stops, meaning screen reader and keyboard-only users could focus the element but perform no action, which violates WCAG accessibility guidelines.
📸 **Before/After:** The visual experience (grayscale filter transitioning to full color on hover/focus) remains exactly the same, but the underlying HTML is now semantically interactive.
♿ **Accessibility:** Replaced dead tab stops with correctly annotated `<a>` tags using `target="_blank"`, `rel="noopener noreferrer"`, and descriptive `aria-label`s. Removed non-functional `tabindex` completely from static elements.

---
*PR created automatically by Jules for task [7609560636820114846](https://jules.google.com/task/7609560636820114846) started by @kastnerp*