### PR TITLE
🎨 Palette: Fix focus ring clipping on video teasers

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -72,6 +72,7 @@ span.faint {
 }
 
 .workflow-teaser video {
+  border-radius: inherit;
   display: block;
   width: 100%;
   height: auto;


### PR DESCRIPTION
🎨 Palette: Add `border-radius: inherit;` to `.workflow-teaser video`

💡 What: Added `border-radius: inherit;` to the `.workflow-teaser video` CSS class.
🎯 Why: Prevents the square corners of the video element's `:focus-visible` outline from visually clipping and clashing against its parent container's rounded corners.
♿ Accessibility: Improves the visual polish of keyboard navigation focus rings on embedded media.

---
*PR created automatically by Jules for task [2384067543915438505](https://jules.google.com/task/2384067543915438505) started by @kastnerp*