### PR TITLE
🎨 Palette: Fix screen reader semantics on team figures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-XX-XX - Dead Tab Stops on Non-Interactive Figures
 **Learning:** Applying `tabindex="0"` to non-interactive `<figure>` elements solely to trigger CSS pseudo-class effects (like `:focus-visible`) creates "dead" tab stops. Screen reader and keyboard users expect focusable elements to be actionable. This is a severe WCAG accessibility violation.
 **Action:** Never use `tabindex="0"` just for visual effects. Instead, either wrap the content in a semantic interactive element (like an `<a>` tag with a verified URL) or remove the focusability entirely if the element is purely static.
+
+## 2024-XX-XX - `aria-label` Overriding Internal DOM Tree Semantics
+**Learning:** Applying an `aria-label` to an `<a>` tag that wraps a complex semantic structure (like a `<figure>` and `<figcaption>`) completely overrides the internal DOM tree for screen readers. The screen reader will announce the label and ignore the internal semantic blocks (e.g., it will skip announcing that it is an image and a caption, stripping away rich structural context).
+**Action:** When adding accessibility context like "(opens in a new tab)" to complex interactive elements like `<figure>` cards, do not place an `aria-label` on the wrapper link. Instead, append a visually hidden span (like `<span class="sr-only"> (opens in a new tab)</span>`) inside the textual component (e.g., the `<figcaption>`) to preserve the internal semantic structure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,23 +168,23 @@ hide:
 <div class="mdx-users">
 
 <figure class="mdx-users__testimonial">
-    <a href="https://yangyang.page/about.html" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Yang Yang (opens in a new tab)">
+    <a href="https://yangyang.page/about.html" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer">
         <img src="assets/images/team/yang.jpg" alt="" loading="lazy" class="skip-lightbox">
-        <figcaption class="md-typeset">Yang Yang</figcaption>
+        <figcaption class="md-typeset">Yang Yang<span class="sr-only"> (opens in a new tab)</span></figcaption>
     </a>
   </figure>
   
   <figure class="mdx-users__testimonial">
-    <a href="https://arch.gatech.edu/people/patrick-kastner" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Patrick Kastner (opens in a new tab)">
+    <a href="https://arch.gatech.edu/people/patrick-kastner" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer">
         <img src="assets/images/team/kastner.jpg" alt="" loading="lazy" class="skip-lightbox">
-        <figcaption class="md-typeset">Patrick Kastner</figcaption>
+        <figcaption class="md-typeset">Patrick Kastner<span class="sr-only"> (opens in a new tab)</span></figcaption>
     </a>
   </figure>
 
   <figure class="mdx-users__testimonial">
-    <a href="https://aap.cornell.edu/people/timur-dogan/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Timur Dogan (opens in a new tab)">
+    <a href="https://aap.cornell.edu/people/timur-dogan/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer">
         <img src="assets/images/team/dogan.jpg" alt="" loading="lazy" class="skip-lightbox">
-        <figcaption class="md-typeset">Timur Dogan</figcaption>
+        <figcaption class="md-typeset">Timur Dogan<span class="sr-only"> (opens in a new tab)</span></figcaption>
     </a>
   </figure>
 
@@ -195,16 +195,16 @@ hide:
 <div class="mdx-users">
 
 <figure class="mdx-users__testimonial">
-    <a href="https://github.com/nikhilsaraf" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Nikhil Saraf (opens in a new tab)">
+    <a href="https://github.com/nikhilsaraf" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer">
         <img src="assets/images/team/saraf.jpg" alt="" loading="lazy" class="skip-lightbox">
-        <figcaption class="md-typeset">Nikhil Saraf</figcaption>
+        <figcaption class="md-typeset">Nikhil Saraf<span class="sr-only"> (opens in a new tab)</span></figcaption>
     </a>
   </figure>
 
   <figure class="mdx-users__testimonial">
-    <a href="https://cee.cornell.edu/samitha/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer" aria-label="Samitha Samaranayake (opens in a new tab)">
+    <a href="https://cee.cornell.edu/samitha/" class="black-and-white" style="display: block; color: inherit; text-decoration: none;" target="_blank" rel="noopener noreferrer">
         <img src="assets/images/team/samitha.jpg" alt="" loading="lazy" class="skip-lightbox">
-        <figcaption class="md-typeset">Samitha Samaranayake</figcaption>
+        <figcaption class="md-typeset">Samitha Samaranayake<span class="sr-only"> (opens in a new tab)</span></figcaption>
     </a>
   </figure>
 


### PR DESCRIPTION
💡 What: Replaced the `aria-label` attribute on the `<a>` tag wrapping team member `<figure>` blocks with a `.sr-only` span appended directly inside the `<figcaption>` in `docs/index.md`. Also added a journal entry explaining this behavior.
🎯 Why: Using `aria-label` on an anchor tag that wraps a complex HTML structure (like an image and a caption) completely overwrites the semantic tree for screen reader users. They hear the label but miss the context that they are navigating an image with a specific caption. Moving the visually hidden text inside the figcaption preserves the rich DOM structure.
♿ Accessibility: Ensures screen reader users retain context of the semantic `<figure>` blocks while still being informed that the links open in a new tab.

---
*PR created automatically by Jules for task [17783436465398628643](https://jules.google.com/task/17783436465398628643) started by @kastnerp*