### PR TITLE
🎨 Palette: Add ARIA labels to MkDocs core dialogs and progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-XX-XX - `aria-label` Overriding Internal DOM Tree Semantics
 **Learning:** Applying an `aria-label` to an `<a>` tag that wraps a complex semantic structure (like a `<figure>` and `<figcaption>`) completely overrides the internal DOM tree for screen readers. The screen reader will announce the label and ignore the internal semantic blocks (e.g., it will skip announcing that it is an image and a caption, stripping away rich structural context).
 **Action:** When adding accessibility context like "(opens in a new tab)" to complex interactive elements like `<figure>` cards, do not place an `aria-label` on the wrapper link. Instead, append a visually hidden span (like `<span class="sr-only"> (opens in a new tab)</span>`) inside the textual component (e.g., the `<figcaption>`) to preserve the internal semantic structure.
+
+## 2024-XX-XX - MkDocs Material Core Accessibility Overrides
+**Learning:** MkDocs Material core components (like `.md-search` and `.md-progress`) may occasionally lack comprehensive ARIA attributes for strict `axe-core` accessibility compliance out-of-the-box. Attempting to fix this via client-side JavaScript is brittle and degrades the core experience for users without JS.
+**Action:** When a core MkDocs Material component is missing critical accessibility attributes (like `aria-label`s on core dialogs/progress bars), use the `docs/overrides/partials/` templating feature to explicitly inject the missing native HTML/ARIA attributes at build time, rather than relying on JS or custom CSS logic.

--- a/docs/overrides/partials/progress.html
+++ b/docs/overrides/partials/progress.html
@@ -1,0 +1,1 @@
+<div class="md-progress" data-md-component="progress" role="progressbar" aria-label="Page load progress" aria-valuemin="0" aria-valuemax="100"></div>

--- a/docs/overrides/partials/search.html
+++ b/docs/overrides/partials/search.html
@@ -1,0 +1,35 @@
+<div class="md-search" data-md-component="search" role="dialog" aria-label="{{ lang.t('search') }}">
+  <label class="md-search__overlay" for="__search"></label>
+  <div class="md-search__inner" role="search">
+    <form class="md-search__form" name="search">
+      <input type="text" class="md-search__input" name="query" aria-label="{{ lang.t('search') }}" placeholder="{{ lang.t('search') }}" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="search-query" required>
+      <label class="md-search__icon md-icon" for="__search">
+        {% include ".icons/material/magnify.svg" %}
+        {% include ".icons/material/arrow-left.svg" %}
+      </label>
+      <nav class="md-search__options" aria-label="{{ lang.t('search') }}">
+        {% if "search.share" in config.theme.features %}
+          <a href="javascript:void(0)" class="md-search__icon md-icon" title="{{ lang.t('search.share') }}" aria-label="{{ lang.t('search.share') }}" data-clipboard data-clipboard-text="" data-md-component="search-share" tabindex="-1">
+            {% include ".icons/material/share-variant.svg" %}
+          </a>
+        {% endif %}
+        <button type="reset" class="md-search__icon md-icon" title="{{ lang.t('search.clear') }}" aria-label="{{ lang.t('search.clear') }}" tabindex="-1">
+          {% include ".icons/material/close.svg" %}
+        </button>
+      </nav>
+      {% if "search.suggest" in config.theme.features %}
+        <div class="md-search__suggest" data-md-component="search-suggest"></div>
+      {% endif %}
+    </form>
+    <div class="md-search__output">
+      <div class="md-search__scrollwrap" tabindex="0" data-md-scrollfix>
+        <div class="md-search-result" data-md-component="search-result">
+          <div class="md-search-result__meta">
+            {{ lang.t("search.result.initializer") }}
+          </div>
+          <ol class="md-search-result__list" role="presentation"></ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
💡 **What: The UX enhancement added:**
Added missing ARIA attributes (`aria-label` and `role`) to the core MkDocs Material search dialog and progress bar components via partial overrides.

🎯 **Why: The user problem it solves:**
Screen reader users previously received no context when encountering the MkDocs search dialog or the page load progress bar. This ensures these core interactive components are properly announced, without relying on brittle client-side JS patching.

📸 **Before/After:**
Visuals remain entirely unchanged, as the overridden templates cleanly inject native HTML/ARIA attributes matching the upstream defaults.

♿ **Accessibility: Any a11y improvements made:**
Resolved critical `aria-dialog-name` and `aria-progressbar-name` axe-core violations on the primary navigation interface.

---
*PR created automatically by Jules for task [6377332071195510723](https://jules.google.com/task/6377332071195510723) started by @kastnerp*