### PR TITLE
🎨 Palette: Distinguish inline links with underline to fix a11y violation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-XX-XX - MkDocs Material Core Accessibility Overrides
 **Learning:** MkDocs Material core components (like `.md-search` and `.md-progress`) may occasionally lack comprehensive ARIA attributes for strict `axe-core` accessibility compliance out-of-the-box. Attempting to fix this via client-side JavaScript is brittle and degrades the core experience for users without JS.
 **Action:** When a core MkDocs Material component is missing critical accessibility attributes (like `aria-label`s on core dialogs/progress bars), use the `docs/overrides/partials/` templating feature to explicitly inject the missing native HTML/ARIA attributes at build time, rather than relying on JS or custom CSS logic.
+
+## 2024-XX-XX - Distinguishing Inline Links from Surrounding Text
+**Learning:** Depending solely on color contrast to distinguish inline text links from surrounding body text is brittle and often fails WCAG `link-in-text-block` requirements, particularly when using custom themes or palettes. Only showing an underline on `:hover` or `:focus` means mobile users or users simply scanning the text cannot easily identify interactive links.
+**Action:** Always provide a permanent, non-color visual indicator for inline links embedded in text blocks. Applying a semi-transparent `text-decoration: underline` that becomes fully opaque on hover provides an elegant solution that satisfies accessibility requirements without visually overwhelming dense text paragraphs.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -146,11 +146,16 @@ span.faint {
   outline-offset: 4px;
 }
 
-/* UX/A11y Standard: Inline links within text blocks must have a visual interactive affordance on hover and focus */
-.md-typeset a:not(.md-button):not(.card):not(.headerlink):hover,
-.md-typeset a:not(.md-button):not(.card):not(.headerlink):focus-visible {
+/* UX/A11y Standard: Inline links within text blocks must be distinguishable from surrounding text */
+.md-typeset a:not(.md-button):not(.card):not(.headerlink):not(.md-content__button) {
   text-decoration: underline;
+  text-decoration-color: var(--md-accent-fg-color-transparent, rgba(64, 81, 181, 0.3));
   text-underline-offset: 2px;
+}
+
+.md-typeset a:not(.md-button):not(.card):not(.headerlink):not(.md-content__button):hover,
+.md-typeset a:not(.md-button):not(.card):not(.headerlink):not(.md-content__button):focus-visible {
+  text-decoration-color: currentColor;
 }
 
 .md-typeset a:not(.md-button):not(.card):not(.headerlink):focus-visible {


### PR DESCRIPTION
💡 **What:** Added a permanent, semi-transparent underline to standard inline text links. The underline becomes solid (currentColor) on `:hover` and `:focus-visible`.
🎯 **Why:** To pass the strict WCAG `link-in-text-block` accessibility guideline, which mandates that links embedded within continuous body text must have a non-color visual indicator (like an underline) so that users do not have to rely solely on color contrast to identify them. 
♿ **Accessibility:** This permanently resolves a `serious` axe-core accessibility violation. It specifically scopes out buttons and structural components to ensure clean aesthetics while drastically improving readability for visually impaired and mobile users.

---
*PR created automatically by Jules for task [11297955204373004682](https://jules.google.com/task/11297955204373004682) started by @kastnerp*