### PR TITLE
🎨 Palette: Add smooth transitions to link text-decoration

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-XX-XX - Distinguishing Inline Links from Surrounding Text
 **Learning:** Depending solely on color contrast to distinguish inline text links from surrounding body text is brittle and often fails WCAG `link-in-text-block` requirements, particularly when using custom themes or palettes. Only showing an underline on `:hover` or `:focus` means mobile users or users simply scanning the text cannot easily identify interactive links.
 **Action:** Always provide a permanent, non-color visual indicator for inline links embedded in text blocks. Applying a semi-transparent `text-decoration: underline` that becomes fully opaque on hover provides an elegant solution that satisfies accessibility requirements without visually overwhelming dense text paragraphs.
+## 2026-05-04 - Smooth Underline Transitions for Inline Links
+**Learning:** In MkDocs Material and custom HTML components, inline links and cards often have `text-decoration: underline` applied abruptly on hover, causing a harsh microscopic layout shift or visual snap that can be jarring to users.
+**Action:** Always apply a transparent baseline underline (`text-decoration: underline; text-decoration-color: transparent;`) to the resting state and animate only the `text-decoration-color` using `transition` on hover and focus. This provides a fluid, high-quality tactile response without DOM layout shifts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,10 @@ hide:
 }
 
 .mdx-users__testimonial figcaption {
-    transition: color 0.3s ease-in-out;
+    transition: color 0.3s ease-in-out, text-decoration-color 0.3s ease-in-out;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 2px;
 }
 
 .mdx-users__testimonial a:active img {
@@ -115,8 +118,7 @@ hide:
 .mdx-users__testimonial a:hover figcaption,
 .mdx-users__testimonial a:focus-visible figcaption {
     color: #007acc;
-    text-decoration: underline;
-    text-underline-offset: 2px;
+    text-decoration-color: #007acc;
 }
 
 .mdx-users__testimonial a:active figcaption {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -151,6 +151,7 @@ span.faint {
   text-decoration: underline;
   text-decoration-color: var(--md-accent-fg-color-transparent, rgba(64, 81, 181, 0.3));
   text-underline-offset: 2px;
+  transition: text-decoration-color 0.2s ease-in-out;
 }
 
 .md-typeset a:not(.md-button):not(.card):not(.headerlink):not(.md-content__button):hover,

--- a/mkdocs_server.log
+++ b/mkdocs_server.log
@@ -1,5 +1,5 @@
 INFO    -  Building documentation...
-INFO    -  CSL file downladed from URL https://raw.githubusercontent.com/citation-style-language/styles/refs/heads/master/american-medical-association-no-url.csl to temporary file (<tempfile._TemporaryFileWrapper object at 0x7f7106568ad0>)
+INFO    -  CSL file downladed from URL https://raw.githubusercontent.com/citation-style-language/styles/refs/heads/master/american-medical-association-no-url.csl to temporary file (<tempfile._TemporaryFileWrapper object at 0x7f1db987ee40>)
 INFO    -  Loading data from bib files: ['/app/papers.bib']
 INFO    -  Cleaning site directory
 WARNING -  Citing unknown reference key Jules
@@ -11,5 +11,5 @@ WARNING -  Citing unknown reference key article
 WARNING -  Citing unknown reference key inproceedings
 WARNING -  Citing unknown reference key article
 WARNING -  Citing unknown reference key article
-INFO    -  Documentation built in 1.18 seconds
-INFO    -  [02:57:02] Serving on http://0.0.0.0:3000/
+INFO    -  Documentation built in 1.15 seconds
+INFO    -  [02:25:32] Serving on http://0.0.0.0:3000/


### PR DESCRIPTION
💡 **What**: Added smooth CSS transitions for inline links and interactive card underlines (`text-decoration-color`) instead of abruptly snapping them into existence.
🎯 **Why**: Instantly adding a `text-decoration` on `:hover` or `:focus-visible` can cause harsh layout shifts and visual snapping. Fading in the color from a `transparent` baseline provides a much more fluid, polished, and premium tactile interaction.
📸 **Before/After**: Hovering over links and cards (like those on the home page) now fades the underline smoothly.
♿ **Accessibility**: Retains the high-contrast link indicator required for WCAG while making the interaction more pleasant and less distracting.

---
*PR created automatically by Jules for task [15092977383243178471](https://jules.google.com/task/15092977383243178471) started by @kastnerp*