### PR TITLE
🎨 Palette: Prevent redundant screen reader announcements on site logo

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-05-04 - Smooth Underline Transitions for Inline Links
 **Learning:** In MkDocs Material and custom HTML components, inline links and cards often have `text-decoration: underline` applied abruptly on hover, causing a harsh microscopic layout shift or visual snap that can be jarring to users.
 **Action:** Always apply a transparent baseline underline (`text-decoration: underline; text-decoration-color: transparent;`) to the resting state and animate only the `text-decoration-color` using `transition` on hover and focus. This provides a fluid, high-quality tactile response without DOM layout shifts.
+
+## 2024-05-10 - Redundant Alt Text on Linked Logos
+**Learning:** In MkDocs Material, the default `partials/logo.html` template uses `alt="logo"` for the site image. However, when the logo is wrapped in an `<a>` tag that already has an explicitly defined `aria-label` (e.g., in `partials/header.html` or `partials/nav.html` where it links back to the home page), the screen reader will redundantly announce both the link's label and the image's "logo" alt text.
+**Action:** To prevent redundant screen reader announcements, override `partials/logo.html` and explicitly set `alt=""`. This ensures that the wrapping link's ARIA label serves as the sole, clear description for the interactive element.

--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,9 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% if config.theme.logo %}
+  <img src="{{ config.theme.logo | url }}" alt="">
+{% else %}
+  {% set icon = config.theme.icon.logo or "material/library" %}
+  {% include ".icons/" ~ icon ~ ".svg" %}
+{% endif %}


### PR DESCRIPTION
💡 What: Overrode the MkDocs Material `partials/logo.html` template to set `alt=""` on the logo image.
🎯 Why: The logo image is automatically wrapped in an anchor tag with an explicit `aria-label="Urbano"` (in headers and navigation). Leaving the default `alt="logo"` caused screen readers to redundantly announce both the label and the image's "logo" text. Setting it to `alt=""` makes the image correctly decorative, leaving the link's ARIA label as the clear, sole descriptor.
♿ Accessibility: Improved screen reader clarity by eliminating redundant semantic noise on the main site logo links.

---
*PR created automatically by Jules for task [7836761916185492319](https://jules.google.com/task/7836761916185492319) started by @kastnerp*