### PR TITLE
🎨 Palette: Fix MkDocs search localization keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2024-05-10 - Redundant Alt Text on Linked Logos
 **Learning:** In MkDocs Material, the default `partials/logo.html` template uses `alt="logo"` for the site image. However, when the logo is wrapped in an `<a>` tag that already has an explicitly defined `aria-label` (e.g., in `partials/header.html` or `partials/nav.html` where it links back to the home page), the screen reader will redundantly announce both the link's label and the image's "logo" alt text.
 **Action:** To prevent redundant screen reader announcements, override `partials/logo.html` and explicitly set `alt=""`. This ensures that the wrapping link's ARIA label serves as the sole, clear description for the interactive element.
+
+## 2024-05-11 - [Search Localization Keys]
+**Learning:** In MkDocs Material custom overrides (e.g., `partials/search.html`), using incorrect or outdated translation keys (like `lang.t('search.clear')` instead of `lang.t('search.reset')` or `lang.t('search')` instead of `lang.t('search.placeholder')`) causes the raw key string to be displayed to users visually and read by screen readers.
+**Action:** When overriding MkDocs Material partials, verify the translation keys against the current version's language files (e.g., `templates/partials/languages/en.html`) to ensure correct localization strings are used.

--- a/docs/overrides/partials/search.html
+++ b/docs/overrides/partials/search.html
@@ -2,7 +2,7 @@
   <label class="md-search__overlay" for="__search"></label>
   <div class="md-search__inner" role="search">
     <form class="md-search__form" name="search">
-      <input type="text" class="md-search__input" name="query" aria-label="{{ lang.t('search') }}" placeholder="{{ lang.t('search') }}" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="search-query" required>
+      <input type="text" class="md-search__input" name="query" aria-label="{{ lang.t('search.placeholder') }}" placeholder="{{ lang.t('search.placeholder') }}" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="search-query" required>
       <label class="md-search__icon md-icon" for="__search">
         {% include ".icons/material/magnify.svg" %}
         {% include ".icons/material/arrow-left.svg" %}
@@ -13,7 +13,7 @@
             {% include ".icons/material/share-variant.svg" %}
           </a>
         {% endif %}
-        <button type="reset" class="md-search__icon md-icon" title="{{ lang.t('search.clear') }}" aria-label="{{ lang.t('search.clear') }}" tabindex="-1">
+        <button type="reset" class="md-search__icon md-icon" title="{{ lang.t('search.reset') }}" aria-label="{{ lang.t('search.reset') }}" tabindex="-1">
           {% include ".icons/material/close.svg" %}
         </button>
       </nav>


### PR DESCRIPTION
🎨 Palette: Fix MkDocs search localization keys

💡 What: Updated the `search.html` partial to use the correct MkDocs Material translation keys. Changed `search.clear` to `search.reset` on the clear button, and `search` to `search.placeholder` on the input element.
🎯 Why: The previous keys were incorrect/outdated for this version of MkDocs Material, causing the raw text "search.clear" to be displayed on the reset button tooltip and read by screen readers.
♿ Accessibility: Ensures screen readers announce properly localized text ("Clear", "Search") instead of raw translation keys ("search.clear").

---
*PR created automatically by Jules for task [12286526102914652996](https://jules.google.com/task/12286526102914652996) started by @kastnerp*