### PR TITLE
🎨 Palette: Improve accessibility of copyright link

### DIFF
--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,0 +1,16 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    Made with
+    <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener noreferrer">
+      Material for MkDocs<span class="sr-only"> (opens in a new tab)</span>
+    </a>
+  {% endif %}
+</div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of copyright link

💡 What: Overrode `partials/copyright.html` to add `rel="noopener noreferrer"` and `<span class="sr-only"> (opens in a new tab)</span>` to the "Material for MkDocs" footer link.
🎯 Why: Enhances security and performance while ensuring screen reader users are explicitly informed when the link opens in a new tab.
♿ Accessibility: Improved screen reader context for external links.

---
*PR created automatically by Jules for task [5014373185823693680](https://jules.google.com/task/5014373185823693680) started by @kastnerp*